### PR TITLE
Laravel 11 php upgrade

### DIFF
--- a/.github/workflows/laravel-repository-build-test.yml
+++ b/.github/workflows/laravel-repository-build-test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         php: ["8.0", "8.1", "8.2"]
-        laravel: ["^6.0", "^7.0", "^8.0", "^9.0", "^10.0"]
+        laravel: ["^6.0", "^7.0", "^8.0", "^9.0", "^10.0", "^11.0"]
         exclude:
           - php: "8.1"
             laravel: "^6.0"
@@ -35,6 +35,10 @@ jobs:
             laravel: "^10.0"
           - php: "8.1"
             laravel: "^10.0"
+          - php: "8.0"
+            laravel: "^11.0"
+          - php: "8.1"
+            laravel: "^11.0"
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.5.0
+
++ Add support for Laravel 11
+
 ## v2.4.0
 
 + Add support for Laravel 10

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,18 @@
         }
     ],
     "require": {
-        "php": "^8.0|^8.1",
+        "php": "^8.0|^8.1|^8.2",
         "ext-json": "*",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/events": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/events": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
         "laravel/legacy-factories": "^1.2"
     },
     "require-dev": {
         "mockery/mockery": "~1.0",
-        "orchestra/testbench": "^4.0||^5.0||^6.0||^7.0||^8.0",
-        "phpunit/phpunit": "^7.3||^8.2||^9.3||^10.0"
+        "orchestra/testbench": "^4.0||^5.0||^6.0||^7.0||^8.0||^9.0",
+        "phpunit/phpunit": "^7.3||^8.2||^9.3||^10.0||^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,33 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         processIsolation="false"
-         stopOnError="false"
-         stopOnFailure="false"
-         verbose="true"
->
-    <testsuites>
-        <testsuite name="LaravelRepository Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
-        <server name="APP_ENV" value="testing"/>
-        <server name="DB_CONNECTION" value="sqlite"/>
-        <server name="DB_DATABASE" value=":memory:"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" beStrictAboutTestsThatDoNotTestAnything="false" bootstrap="vendor/autoload.php" colors="true" failOnRisky="true" failOnWarning="true" processIsolation="false" stopOnError="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="LaravelRepository Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
+    <server name="APP_ENV" value="testing"/>
+    <server name="DB_CONNECTION" value="sqlite"/>
+    <server name="DB_DATABASE" value=":memory:"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/Unit/EloquentRepositoryEventTest.php
+++ b/tests/Unit/EloquentRepositoryEventTest.php
@@ -14,6 +14,7 @@ use Lerouse\LaravelRepository\RepositoryInterface;
 use Lerouse\LaravelRepository\Tests\Fixtures\Models\TestModel;
 use Lerouse\LaravelRepository\Tests\Fixtures\Repositories\TestModelRepository;
 use Lerouse\LaravelRepository\Tests\LaravelTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class EloquentRepositoryEventTest extends LaravelTestCase
 {
@@ -32,7 +33,7 @@ class EloquentRepositoryEventTest extends LaravelTestCase
         Event::fake();
     }
 
-    /** @test **/
+    #[Test]
     public function creating_a_model_fires_event(): void
     {
         $model = $this->repository->create(['value' => 'Test Model']);
@@ -42,7 +43,7 @@ class EloquentRepositoryEventTest extends LaravelTestCase
         });
     }
 
-    /** @test **/
+    #[Test]
     public function updating_a_model_fires_event(): void
     {
         $model = factory(TestModel::class)->create();
@@ -54,7 +55,7 @@ class EloquentRepositoryEventTest extends LaravelTestCase
         });
     }
 
-    /** @test **/
+    #[Test]
     public function deleting_a_model_fires_event(): void
     {
         $model = factory(TestModel::class)->create();
@@ -66,7 +67,7 @@ class EloquentRepositoryEventTest extends LaravelTestCase
         });
     }
 
-    /** @test **/
+    #[Test]
     public function creating_many_models_fires_event(): void
     {
         $this->repository->createMany([
@@ -79,7 +80,7 @@ class EloquentRepositoryEventTest extends LaravelTestCase
         });
     }
 
-    /** @test **/
+    #[Test]
     public function updating_many_models_fires_event(): void
     {
         $collection = factory(TestModel::class, 2)->create();
@@ -93,7 +94,7 @@ class EloquentRepositoryEventTest extends LaravelTestCase
         });
     }
 
-    /** @test **/
+    #[Test]
     public function deleting_many_models_fires_event(): void
     {
         $collection = factory(TestModel::class, 2)->create();

--- a/tests/Unit/EloquentRepositoryTest.php
+++ b/tests/Unit/EloquentRepositoryTest.php
@@ -9,6 +9,7 @@ use Lerouse\LaravelRepository\RepositoryInterface;
 use Lerouse\LaravelRepository\Tests\Fixtures\Models\TestModel;
 use Lerouse\LaravelRepository\Tests\Fixtures\Repositories\TestModelRepository;
 use Lerouse\LaravelRepository\Tests\LaravelTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class EloquentRepositoryTest extends LaravelTestCase
 {
@@ -23,13 +24,13 @@ class EloquentRepositoryTest extends LaravelTestCase
         $this->repository = new TestModelRepository;
     }
 
-    /** @test **/
+    #[Test]
     public function can_create_an_eloquent_repository(): void
     {
         self::assertInstanceOf(EloquentRepository::class, $this->repository);
     }
 
-    /** @test **/
+    #[Test]
     public function can_retrieve_all(): void
     {
         $collection = factory(TestModel::class, 2)->create();
@@ -38,7 +39,7 @@ class EloquentRepositoryTest extends LaravelTestCase
     }
 
 
-    /** @test **/
+    #[Test]
     public function can_find(): void
     {
         $model = factory(TestModel::class)->create();
@@ -46,7 +47,7 @@ class EloquentRepositoryTest extends LaravelTestCase
         self::assertEquals($model->toArray(), $this->repository->find($model->getKey())->toArray());
     }
 
-    /** @test **/
+    #[Test]
     public function finding_a_model_throws_exception_if_not_found(): void
     {
         $this->expectException(ModelNotFoundException::class);
@@ -54,14 +55,14 @@ class EloquentRepositoryTest extends LaravelTestCase
         $this->repository->find(1);
     }
 
-    /** @test **/
+    #[Test]
     public function finding_a_model_that_is_not_found_with_fail_set_to_false_returns_null(): void
     {
         self::assertNull($this->repository->find(1, false));
 
     }
 
-    /** @test **/
+    #[Test]
     public function can_find_many(): void
     {
         $collection = factory(TestModel::class, 2)->create();
@@ -71,7 +72,7 @@ class EloquentRepositoryTest extends LaravelTestCase
         self::assertEquals($collection->toArray(), $this->repository->findMany($ids)->toArray());
     }
 
-    /** @test **/
+    #[Test]
     public function can_create(): void
     {
         $this->repository->create([
@@ -84,7 +85,7 @@ class EloquentRepositoryTest extends LaravelTestCase
         ]);
     }
 
-    /** @test **/
+    #[Test]
     public function can_create_many(): void
     {
         $this->repository->createMany([
@@ -103,7 +104,7 @@ class EloquentRepositoryTest extends LaravelTestCase
         ]);
     }
 
-    /** @test **/
+    #[Test]
     public function can_update(): void
     {
         $model = factory(TestModel::class)->create();
@@ -118,7 +119,7 @@ class EloquentRepositoryTest extends LaravelTestCase
         ]);
     }
 
-    /** @test **/
+    #[Test]
     public function can_update_many(): void
     {
         $collection = factory(TestModel::class, 2)->create();
@@ -138,7 +139,7 @@ class EloquentRepositoryTest extends LaravelTestCase
         ]);
     }
 
-    /** @test **/
+    #[Test]
     public function can_delete(): void
     {
         $model = factory(TestModel::class)->create();
@@ -150,7 +151,7 @@ class EloquentRepositoryTest extends LaravelTestCase
         ]);
     }
 
-    /** @test **/
+    #[Test]
     public function can_delete_many(): void
     {
         $collection = factory(TestModel::class, 2)->create();
@@ -166,7 +167,7 @@ class EloquentRepositoryTest extends LaravelTestCase
         ]);
     }
 
-    /** @test **/
+    #[Test]
     public function can_get_next_auto_increment(): void
     {
         factory(TestModel::class, 2)->create();
@@ -174,13 +175,13 @@ class EloquentRepositoryTest extends LaravelTestCase
         self::assertEquals(3, $this->repository->getNextAutoIncrement());
     }
 
-    /** @test **/
+    #[Test]
     public function get_next_auto_increment_on_empty_table_returns_one(): void
     {
         self::assertEquals(1, $this->repository->getNextAutoIncrement());
     }
 
-    /** @test **/
+    #[Test]
     public function can_get_models_primary_key(): void
     {
         $reflection = new \ReflectionClass(TestModelRepository::class);
@@ -192,7 +193,7 @@ class EloquentRepositoryTest extends LaravelTestCase
         self::assertEquals('id', $method->invokeArgs($this->repository, []));
     }
 
-    /** @test **/
+    #[Test]
     public function can_get_models_table(): void
     {
         $reflection = new \ReflectionClass(TestModelRepository::class);
@@ -204,7 +205,7 @@ class EloquentRepositoryTest extends LaravelTestCase
         self::assertEquals('test_models', $method->invokeArgs($this->repository, []));
     }
 
-    /** @test **/
+    #[Test]
     public function can_get_builder(): void
     {
         self::assertInstanceOf(Builder::class, $this->repository->builder());

--- a/tests/Unit/HasRepositoryTest.php
+++ b/tests/Unit/HasRepositoryTest.php
@@ -8,12 +8,13 @@ use Lerouse\LaravelRepository\Tests\Fixtures\Models\FailedModel;
 use Lerouse\LaravelRepository\Tests\Fixtures\Models\TestModel;
 use Lerouse\LaravelRepository\Tests\Fixtures\Repositories\TestModelRepository;
 use Lerouse\LaravelRepository\Tests\LaravelTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class HasRepositoryTest extends LaravelTestCase
 {
     use RefreshDatabase;
 
-    /** @test **/
+    #[Test]
     public function can_get_models_repository(): void
     {
         $model = new TestModel;
@@ -23,7 +24,7 @@ class HasRepositoryTest extends LaravelTestCase
         self::assertInstanceOf(TestModelRepository::class, $repository);
     }
 
-    /** @test **/
+    #[Test]
     public function can_get_model_repository_namespace(): void
     {
         $model = new TestModel;
@@ -31,7 +32,7 @@ class HasRepositoryTest extends LaravelTestCase
         self::assertEquals('Lerouse\LaravelRepository\Tests\Fixtures\Repositories', $model->getRepositoryNamespace());
     }
 
-    /** @test **/
+    #[Test]
     public function can_get_route_model_binding_via_repository(): void
     {
         $testModel = factory(TestModel::class)->create();
@@ -44,7 +45,7 @@ class HasRepositoryTest extends LaravelTestCase
         );
     }
 
-    /** @test **/
+    #[Test]
     public function route_model_binding_via_repository_returns_null_if_no_model_available(): void
     {
         $model = new TestModel;
@@ -52,7 +53,7 @@ class HasRepositoryTest extends LaravelTestCase
         self::assertNull($model->resolveRouteBinding(1));
     }
 
-    /** @test **/
+    #[Test]
     public function model_missing_repository_throws_exception(): void
     {
         $this->expectException(RepositoryNotFoundException::class);
@@ -63,7 +64,7 @@ class HasRepositoryTest extends LaravelTestCase
         $model->getRepository();
     }
 
-    /** @test **/
+    #[Test]
     public function route_model_binding_throws_exception_if_no_repository_available(): void
     {
 

--- a/tests/Unit/RepositoryManagerServiceTest.php
+++ b/tests/Unit/RepositoryManagerServiceTest.php
@@ -7,23 +7,24 @@ use Lerouse\LaravelRepository\Services\RepositoryManagerService;
 use Lerouse\LaravelRepository\Tests\Fixtures\Models\TestModel;
 use Lerouse\LaravelRepository\Tests\Fixtures\Repositories\TestModelRepository;
 use Lerouse\LaravelRepository\Tests\LaravelTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class RepositoryManagerServiceTest extends LaravelTestCase
 {
 
-    /** @test **/
+    #[Test]
     public function can_load_a_repository(): void
     {
         $this->assertInstanceOf(TestModelRepository::class, $this->getRepositoryManager()->getRepository('TestModel'));
     }
 
-    /** @test **/
+    #[Test]
     public function can_load_repository_with_appending_text(): void
     {
         $this->assertInstanceOf(TestModelRepository::class, $this->getRepositoryManager()->getRepository('TestModelRepository'));
     }
 
-    /** @test **/
+    #[Test]
     public function exception_thrown_if_repository_does_not_exist(): void
     {
         $this->expectException(RepositoryNotFoundException::class);
@@ -31,19 +32,19 @@ class RepositoryManagerServiceTest extends LaravelTestCase
         $this->assertInstanceOf(TestModelRepository::class, $this->getRepositoryManager()->getRepository('FakeRepository'));
     }
 
-    /** @test **/
+    #[Test]
     public function can_load_repository_using_fqdn(): void
     {
         $this->assertInstanceOf(TestModelRepository::class, $this->getRepositoryManager()->getRepository(TestModel::class));
     }
 
-    /** @test **/
+    #[Test]
     public function can_load_repository_using_repositories_fqdn(): void
     {
         $this->assertInstanceOf(TestModelRepository::class, $this->getRepositoryManager()->getRepository(TestModelRepository::class));
     }
 
-    /** @test **/
+    #[Test]
     public function exception_thrown_if_repository_fqdn_does_not_exist(): void
     {
         $this->expectException(RepositoryNotFoundException::class);

--- a/tests/Unit/UsesRepositoryManagerTest.php
+++ b/tests/Unit/UsesRepositoryManagerTest.php
@@ -7,24 +7,25 @@ use Lerouse\LaravelRepository\Support\UsesRepositoryManager;
 use Lerouse\LaravelRepository\Tests\Fixtures\Models\TestModel;
 use Lerouse\LaravelRepository\Tests\Fixtures\Repositories\TestModelRepository;
 use Lerouse\LaravelRepository\Tests\LaravelTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class UsesRepositoryManagerTest extends LaravelTestCase
 {
     use UsesRepositoryManager;
 
-    /** @test **/
+    #[Test]
     public function can_load_a_repository(): void
     {
         $this->assertInstanceOf(TestModelRepository::class, $this->getRepository('TestModel'));
     }
 
-    /** @test **/
+    #[Test]
     public function can_load_repository_with_appending_text(): void
     {
         $this->assertInstanceOf(TestModelRepository::class, $this->getRepository('TestModelRepository'));
     }
 
-    /** @test **/
+    #[Test]
     public function exception_thrown_if_repository_does_not_exist(): void
     {
         $this->expectException(RepositoryNotFoundException::class);
@@ -32,19 +33,19 @@ class UsesRepositoryManagerTest extends LaravelTestCase
        $this->getRepository('FakeRepository');
     }
 
-    /** @test **/
+    #[Test]
     public function can_load_repository_using_fqdn(): void
     {
         $this->assertInstanceOf(TestModelRepository::class, $this->getRepository(TestModel::class));
     }
 
-    /** @test **/
+    #[Test]
     public function can_load_repository_using_repositories_fqdn(): void
     {
         $this->assertInstanceOf(TestModelRepository::class, $this->getRepositoryManager()->getRepository(TestModelRepository::class));
     }
 
-    /** @test **/
+    #[Test]
     public function exception_thrown_if_repository_fqdn_does_not_exist(): void
     {
         $this->expectException(RepositoryNotFoundException::class);


### PR DESCRIPTION
Hi, I tried to install this package but couldn't because it wasn't compatible with Laravel 11. 
For this reason, I want to collaborate to make it possible to install it with this version.

To make this pull request, I've based myself on this pull request (https://github.com/lerouse/laravel-repository/pull/3/files).

The changes are basic and very similar to the pull request mentioned (Add version 11).

In addition to that, I've modified the tests because it gave me warnings ["metadata in doc-comments is deprecated [...] use attributes instead"](https://www.conroyp.com/articles/phpunit-deprecated-metadata-doc-comments-use-attributes-instead).

On the other hand, I've made changes in the "phpunit.xml.dist" file because when I ran the local tests it gave me a warning because the XML schema validation was deprecated.